### PR TITLE
feat: change add button to purple and background to light blue

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,7 +14,7 @@ body {
     'Helvetica Neue', Arial, sans-serif;
   padding: 2rem;
   color: #333;
-  background-color: #f5f5f5;
+  background-color: #d6eaf8;
 }
 
 .app {
@@ -67,12 +67,12 @@ p {
 }
 
 .btn-primary {
-  background-color: #3498db;
+  background-color: #9b59b6;
   color: white;
 }
 
 .btn-primary:hover {
-  background-color: #2980b9;
+  background-color: #8e44ad;
 }
 
 .btn-delete {


### PR DESCRIPTION
## Summary
- Changed the "Añadir" button color from blue to **purple/lilac** (`#9b59b6`)
- Changed the page background from gray to **light blue** (`#d6eaf8`)

Closes #4

## Test plan
- [ ] Verify the "Añadir" button displays in purple
- [ ] Verify the page background is light blue
- [ ] Verify hover state on button shows darker purple

🤖 Generated with [Claude Code](https://claude.com/claude-code)