### PR TITLE
feat: add emoji prefix to tasks based on keywords

### DIFF
--- a/frontend/src/components/TaskItem.jsx
+++ b/frontend/src/components/TaskItem.jsx
@@ -1,6 +1,33 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 
+const EMOJI_KEYWORDS = [
+  [/\b(compra|tienda|supermercado|mercado)\b/i, '🛒'],
+  [/\b(leche|comida|comer|cocina|cocinar|receta|almuerzo|cena|desayuno)\b/i, '🍽️'],
+  [/\b(llam|tele|teléfono|móvil|celular)\b/i, '📞'],
+  [/\b(doctor|médico|salud|hospital|cita|dentista|medicina)\b/i, '🏥'],
+  [/\b(correo|email|mensaje|carta|enviar)\b/i, '📧'],
+  [/\b(reporte|informe|documento|archivo|excel|pdf)\b/i, '📄'],
+  [/\b(reunión|meeting|junta|equipo)\b/i, '👥'],
+  [/\b(estudiar|estudio|libro|leer|lectura|curso|clase|examen)\b/i, '📚'],
+  [/\b(ejercicio|gym|gimnasio|correr|deporte|entrenar)\b/i, '🏋️'],
+  [/\b(limpiar|limpieza|ordenar|barrer|fregar)\b/i, '🧹'],
+  [/\b(viaje|viajar|vuelo|hotel|vacaciones|maleta)\b/i, '✈️'],
+  [/\b(trabajo|oficina|proyecto|tarea)\b/i, '💼'],
+  [/\b(pagar|pago|banco|dinero|factura|cuenta)\b/i, '💰'],
+  [/\b(cumpleaños|fiesta|regalo|celebr)\b/i, '🎉'],
+  [/\b(mascota|perro|gato|veterinario)\b/i, '🐾'],
+  [/\b(presentación|diapositiva|slide|powerpoint|preparar)\b/i, '📊'],
+  [/\b(revisar|revisión|check|verificar)\b/i, '✅'],
+]
+
+function getTaskEmoji(title) {
+  for (const [pattern, emoji] of EMOJI_KEYWORDS) {
+    if (pattern.test(title)) return emoji
+  }
+  return '📌'
+}
+
 function TaskItem({ task, onToggle, onDelete }) {
   const {
     attributes,
@@ -31,7 +58,7 @@ function TaskItem({ task, onToggle, onDelete }) {
         className="task-checkbox"
       />
       <span className={task.completed ? 'task-title completed' : 'task-title'}>
-        {task.title}
+        {getTaskEmoji(task.title)} {task.title}
       </span>
       <button
         onClick={() => onDelete(task.id)}


### PR DESCRIPTION
## Summary
- Adds an emoji at the beginning of each task title based on keyword recognition
- Detects words like "comprar", "doctor", "correo", "presentación", etc. and maps them to relevant emojis
- Falls back to 📌 when no keyword is matched

Closes #6

## Test plan
- [ ] Verify each seeded task shows a relevant emoji
- [ ] Add a new task with a recognizable keyword and verify correct emoji
- [ ] Add a task with no recognizable keyword and verify 📌 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)